### PR TITLE
Update role to work both in Ubuntu and RedHat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 - name: install ipmitool
-  yum: pkg=ipmitool state=present
+  apt: pkg=ipmitool state=latest
+  when: ansible_pkg_mgr=="apt"
+  tags: ipmi, packages
+
+- name: install ipmitool
+  yum: pkg=ipmitool state=latest
+  when: ansible_pkg_mgr=="yum"
   tags: ipmi, packages
 
 - name: load ipmi kernel modules


### PR DESCRIPTION
Hi!

I saw your fork of ansible_ipmi_lan_manage, and added both Ubuntu and CentOS/RedHat support to the role. You can check it out in my repo.

P.S. If my work is useful -  you may put a star on it's github repo.
